### PR TITLE
Fixed a crash when cached node is twice in the stack and cached data isn't cleaned properly.

### DIFF
--- a/src/socialnetworkinterface.cpp
+++ b/src/socialnetworkinterface.cpp
@@ -397,7 +397,7 @@ void SocialNetworkInterfacePrivate::maybePurgeDoomedNodes(int count, int directi
             // so we have to delete it and purge our cache of content items for the node.
             purgeDoomedNode(doomedNode);
         } else {
-            qWarning() << Q_FUNC_INFO << "XXXX Node found from the stack!" << doomedNode->identifier();
+            qWarning() << Q_FUNC_INFO << "Node found from the stack. Could not purge the data." << doomedNode->identifier();
         }
     }
 


### PR DESCRIPTION
I'm not sure if this is the right way to fix this problem, but now the node can appear only once in the nodeStack. After this change I couldn't make it crash anymore.

L448-450: Removes the node from the nodeStack cache if it's already there. After this node's data can be cleared and then node is added on top of the nodeStack.

L967-970: Tries to remove corrupted data from the cache.
