### PR TITLE
[nemo-qml-plugins-social] By default node caching is disabled. It's poss...

### DIFF
--- a/src/socialnetworkinterface.cpp
+++ b/src/socialnetworkinterface.cpp
@@ -196,6 +196,7 @@ SocialNetworkInterfacePrivate::SocialNetworkInterfacePrivate(SocialNetworkInterf
     , currentNodePosition(-1)
     , nodeStackSize(5)
     , arbitraryRequestHandler(0)
+    , cacheMode(false)
 {
 }
 
@@ -460,6 +461,10 @@ void SocialNetworkInterfacePrivate::pushNode(IdentifiableContentItemInterface *n
 /*! \internal */
 void SocialNetworkInterfacePrivate::nextNode()
 {
+    if (!cacheMode) {
+        qWarning() << Q_FUNC_INFO << "Set cacheMode property to true to use nextNode()";
+        return;
+    }
     // the caller is responsible for emitting dataChanged() etc.
 
     if (currentNodePosition == -1 || nodeStack.size() == 0) {
@@ -478,6 +483,10 @@ void SocialNetworkInterfacePrivate::nextNode()
 /*! \internal */
 void SocialNetworkInterfacePrivate::prevNode()
 {
+    if (!cacheMode) {
+        qWarning() << Q_FUNC_INFO << "Set cacheMode property to true to use prevNode()";
+        return;
+    }
     // the caller is responsible for emitting dataChanged() etc.
 
     if (currentNodePosition == -1 || nodeStack.size() == 0) {
@@ -880,6 +889,20 @@ QString SocialNetworkInterface::errorMessage() const
     return d->errorMessage;
 }
 
+
+/*!
+    \qmlproperty bool SocialNetwork:cacheMode
+    Enables or disables cache mode for this Facebook element. When using
+    cacheMode, the node data will be cached and once fetched data can be populated
+    faster. Current cache limit is set to 5 nodes. If cache limit is exceeded, the
+    oldest data will be purged.
+ */
+bool SocialNetworkInterface::cacheMode() const
+{
+    Q_D(const SocialNetworkInterface);
+    return d->cacheMode;
+}
+
 /*!
     \qmlproperty QString SocialNetwork::nodeIdentifier
     Holds the identifier of the "central" content item.  This content item
@@ -926,7 +949,7 @@ void SocialNetworkInterface::setNodeIdentifier(const QString &contentItemIdentif
         d->repopulatingCurrentNode = true;
         d->pendingCurrentNodeIdentifier = contentItemIdentifier;
         populateDataForNode(contentItemIdentifier); // "unseen node" without pushing placeholder.
-    } else if (!cachedNode) {
+    } else if (!d->cacheMode || !cachedNode) {
         // Unseen node.
         // call derived class data populate:
         //   d->populateCache() etc once it's finished retrieving.
@@ -987,6 +1010,15 @@ void SocialNetworkInterface::setRelevanceCriteria(const QVariantMap &relevanceCr
     if (d->relevanceCriteria != relevanceCriteria) {
         d->relevanceCriteria = relevanceCriteria;
         emit relevanceCriteriaChanged();
+    }
+}
+
+void SocialNetworkInterface::setCacheMode(bool enable)
+{
+    Q_D(SocialNetworkInterface);
+    if (d->cacheMode != enable) {
+        d->cacheMode = enable;
+        emit cacheModeChanged();
     }
 }
 

--- a/src/socialnetworkinterface.h
+++ b/src/socialnetworkinterface.h
@@ -69,6 +69,7 @@ class SocialNetworkInterface : public QAbstractListModel, public QDeclarativePar
     Q_PROPERTY(Status status READ status NOTIFY statusChanged)
     Q_PROPERTY(ErrorType error READ error NOTIFY errorChanged)
     Q_PROPERTY(QString errorMessage READ errorMessage NOTIFY errorMessageChanged)
+    Q_PROPERTY(bool cacheMode READ cacheMode WRITE setCacheMode NOTIFY cacheModeChanged)
 
     Q_ENUMS(Status)
     Q_ENUMS(ErrorType)
@@ -132,6 +133,7 @@ public:
     Status status() const;
     ErrorType error() const;
     QString errorMessage() const;
+    bool cacheMode() const;
 
     QString nodeIdentifier() const;
     IdentifiableContentItemInterface *node() const;
@@ -143,6 +145,7 @@ public:
     // Property mutators.
     void setNodeIdentifier(const QString &contentItemIdentifier);
     void setRelevanceCriteria(const QVariantMap &relevanceCriteria);
+    void setCacheMode(bool enable);
 
 Q_SIGNALS:
     void statusChanged();
@@ -153,6 +156,7 @@ Q_SIGNALS:
     void nodeChanged();
     void relevanceCriteriaChanged();
     void countChanged();
+    void cacheModeChanged();
 
 public:
     Q_INVOKABLE bool arbitraryRequest(int requestType, const QString &requestUri,

--- a/src/socialnetworkinterface_p.h
+++ b/src/socialnetworkinterface_p.h
@@ -165,6 +165,7 @@ private:
     QMultiHash<IdentifiableContentItemInterface*, CacheEntry*> nodeContent; // cache entries which are connections/related content for a given node
 
     ArbitraryRequestHandler *arbitraryRequestHandler;
+    bool cacheMode;
 
     Q_DECLARE_PUBLIC(SocialNetworkInterface)
 };


### PR DESCRIPTION
I'm not very proud of this, but I'm not really sure how to fix crash caused by node caching. For a workaround, caching is disabled by default and there is a new property "cacheMode" which can be used for enabling and disabling caching. By default it disables it.

Please review the previous PR about Undefined reference crash fix also and apply that too (if you'll accept it). 
