### PR TITLE
Added support for sections

### DIFF
--- a/src/facebook/facebookinterface.cpp
+++ b/src/facebook/facebookinterface.cpp
@@ -584,6 +584,18 @@ QNetworkReply *FacebookInterface::deleteRequest(const QString &objectIdentifier,
 }
 
 /*! \reimp */
+QString FacebookInterface::dataSection(int type, const QVariantMap &data) const
+{
+    switch (type) {
+    case User:
+        return data.value(FACEBOOK_ONTOLOGY_USER_NAME).toString();
+    default:
+        break;
+    }
+    return SocialNetworkInterface::dataSection(type, data);
+}
+
+/*! \reimp */
 void FacebookInterface::updateInternalData(QList<CacheEntry*> data)
 {
     Q_D(FacebookInterface);

--- a/src/facebook/facebookinterface.h
+++ b/src/facebook/facebookinterface.h
@@ -100,6 +100,7 @@ protected:
     QNetworkReply *getRequest(const QString &objectIdentifier, const QString &extraPath, const QStringList &whichFields, const QVariantMap &extraData);
     QNetworkReply *postRequest(const QString &objectIdentifier, const QString &extraPath, const QVariantMap &data, const QVariantMap &extraData);
     QNetworkReply *deleteRequest(const QString &objectIdentifier, const QString &extraPath, const QVariantMap &extraData);
+    QString dataSection(int type, const QVariantMap &data) const;
     void updateInternalData(QList<CacheEntry*> data);
     void populateDataForNode(IdentifiableContentItemInterface *currentNode);
     void populateDataForNode(const QString &unseenNodeIdentifier);

--- a/src/socialnetworkinterface.cpp
+++ b/src/socialnetworkinterface.cpp
@@ -216,6 +216,7 @@ void SocialNetworkInterfacePrivate::init()
     headerData.insert(SocialNetworkInterface::ContentItemTypeRole, "contentItemType");
     headerData.insert(SocialNetworkInterface::ContentItemDataRole, "contentItemData" );
     headerData.insert(SocialNetworkInterface::ContentItemIdentifierRole, "contentItemIdentifier");
+    headerData.insert(SocialNetworkInterface::SectionRole, "section");
     q->setRoleNames(headerData);
 
     // Construct the placeholder node.  This node is used as a placeholder
@@ -1066,10 +1067,14 @@ QVariant SocialNetworkInterface::data(const QModelIndex &index, int role) const
     CacheEntry *cacheEntry = d->internalData.at(index.row());
 
     switch (role) {
-        case ContentItemTypeRole: return QVariant::fromValue(cacheEntry->data.value(NEMOQMLPLUGINS_SOCIAL_CONTENTITEMTYPE).toInt());
-        case ContentItemDataRole: return QVariant::fromValue(cacheEntry->data);
-        case ContentItemIdentifierRole: return QVariant::fromValue(cacheEntry->data.value(NEMOQMLPLUGINS_SOCIAL_CONTENTITEMID).toString());
-        case ContentItemRole: {
+    case ContentItemTypeRole:
+        return QVariant::fromValue(cacheEntry->data.value(NEMOQMLPLUGINS_SOCIAL_CONTENTITEMTYPE).toInt());
+    case ContentItemDataRole:
+        return QVariant::fromValue(cacheEntry->data);
+    case ContentItemIdentifierRole:
+        return QVariant::fromValue(cacheEntry->data.value(NEMOQMLPLUGINS_SOCIAL_CONTENTITEMID).toString());
+    case ContentItemRole:
+        {
             if (cacheEntry->item)
                 return QVariant::fromValue(cacheEntry->item);
             // instantiate the item.
@@ -1078,7 +1083,10 @@ QVariant SocialNetworkInterface::data(const QModelIndex &index, int role) const
             return QVariant::fromValue(newItem);
         }
         break;
-        default: return QVariant();
+    case SectionRole:
+        return dataSection(cacheEntry->data.value(NEMOQMLPLUGINS_SOCIAL_CONTENTITEMTYPE).toInt(), cacheEntry->data);
+    default:
+        return QVariant();
     }
 }
 
@@ -1190,6 +1198,16 @@ QNetworkReply *SocialNetworkInterface::deleteRequest(const QString &, const QStr
 {
     qWarning() << Q_FUNC_INFO << "Error: this function MUST be implemented by derived types!";
     return 0;
+}
+
+/*
+    TODO: do the documentation
+*/
+QString SocialNetworkInterface::dataSection(int type, const QVariantMap &data) const
+{
+    Q_UNUSED(type)
+    Q_UNUSED(data)
+    return QString();
 }
 
 /*

--- a/src/socialnetworkinterface.h
+++ b/src/socialnetworkinterface.h
@@ -97,7 +97,8 @@ public:
         ContentItemRole = Qt::UserRole + 1,
         ContentItemTypeRole,
         ContentItemDataRole,
-        ContentItemIdentifierRole // 0 for unidentifiable content items
+        ContentItemIdentifierRole, // 0 for unidentifiable content items
+        SectionRole
     };
     enum ContentType {
         NotInitialized = 0,
@@ -176,6 +177,7 @@ protected:
     void setContentItemData(ContentItemInterface *contentItem, const QVariantMap &data) const;
 
     // Virtual methods
+    virtual QString dataSection(int type, const QVariantMap &data) const;
     virtual ContentItemInterface *contentItemFromData(QObject *parent, const QVariantMap &data) const;
     virtual void updateInternalData(QList<CacheEntry*> data);                         // model data, requires filter/sort/dataChanged()
     virtual void populateDataForNode(IdentifiableContentItemInterface *currentNode);  // requires d->populateCache() + updateInternalData()


### PR DESCRIPTION
This commit provides a new role in SocialNetworkInterface,
"section", that can be passed to ListView.section.property.

Providing "section" properties should be done for subclasses
of SocialNetworkInterface, by implementing
SocialNetworkInterface::dataSection, for relevant data types.
