### PR TITLE
[nemo-qml-plugin-social] Crash fix

### DIFF
--- a/src/identifiablecontentiteminterface.cpp
+++ b/src/identifiablecontentiteminterface.cpp
@@ -499,6 +499,12 @@ bool IdentifiableContentItemInterface::request(IdentifiableContentItemInterface:
         break;
     }
 
+    // Due the network unlinearity just make sure that the old reply has been deleted and
+    // ignored before assigning a new one to it.
+    if (d->currentReply != 0) {
+        d->deleteReply();
+    }
+
     if (reply) {
         d->currentReply = reply;
         d->status = SocialNetworkInterface::Busy;

--- a/src/identifiablecontentiteminterface_p.h
+++ b/src/identifiablecontentiteminterface_p.h
@@ -46,7 +46,7 @@ class IdentifiableContentItemInterfacePrivate : public ContentItemInterfacePriva
 {
 public:
     explicit IdentifiableContentItemInterfacePrivate(IdentifiableContentItemInterface *q);
-    ~IdentifiableContentItemInterfacePrivate();
+    virtual ~IdentifiableContentItemInterfacePrivate();
 
     QNetworkReply *reply(); // returns currentReply
     void deleteReply();     // disconnect()s and then deleteLater()s currentReply, sets to null.  DOES NOT SET STATE.


### PR DESCRIPTION
Added virtual keyword for destructor to the baseclass' and double checked if the network reply needed to be cleaned before assigning a new one. 

This fixed one crash problem for FacebookPhoto element.
