### PR TITLE
Bugfix to the Qt5 port

### DIFF
--- a/social.pro
+++ b/social.pro
@@ -5,4 +5,7 @@ tests.depends = src
 
 OTHER_FILES += \
     rpm/nemo-qml-plugin-social.yaml \
-    rpm/nemo-qml-plugin-social.spec
+    rpm/nemo-qml-plugin-social.spec \
+    rpm/nemo-qml-plugin-social-qt5.yaml \
+    rpm/nemo-qml-plugin-social-qt5.spec
+

--- a/src/facebook/facebookinterface.cpp
+++ b/src/facebook/facebookinterface.cpp
@@ -154,9 +154,9 @@ QUrl FacebookInterfacePrivate::requestUrl(const QString &objectId, const QString
     retn.setScheme("https");
     retn.setHost("graph.facebook.com");
     if (extraPath.isEmpty())
-        retn.setPath(objectId);
+        retn.setPath(QLatin1String("/") + objectId);
     else
-        retn.setPath(objectId + QLatin1String("/") + extraPath);
+        retn.setPath(QLatin1String("/") + objectId + QLatin1String("/") + extraPath);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
     QUrlQuery query;
     query.setQueryItems(queryItems);


### PR DESCRIPTION
In Qt5, path provided to QUrl are more strictly checked.
In social, the paths were provided without the first "/",
resulting in a silent fail in the test program.

It is fixed in this commit. Therefore the test program
works now in Qt4 and Qt5.
