### PR TITLE
Added a gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Qt Creator files
+*.pro.user
+qtc_packaging
+tests/socialtest/qt5
+
+# Compilation files
+.moc
+.obj
+build
+install
+
+# Python object files
+*.pyc


### PR DESCRIPTION
Added a simple gitignore. It ignores Qt Creator files (.pro.user), build directories (especially .moc and .obj), and python object files. (.pyc)
