### PR TITLE
Bugfixes (and get likes and comments)

### DIFF
--- a/src/facebook/facebookalbuminterface.h
+++ b/src/facebook/facebookalbuminterface.h
@@ -60,6 +60,8 @@ class FacebookAlbumInterface: public IdentifiableContentItemInterface
     Q_PROPERTY(QString updatedTime READ updatedTime NOTIFY updatedTimeChanged)
     Q_PROPERTY(bool canUpload READ canUpload NOTIFY canUploadChanged)
     Q_PROPERTY(bool liked READ liked NOTIFY likedChanged)
+    Q_PROPERTY(int likesCount READ likesCount NOTIFY likesCountChanged)
+    Q_PROPERTY(int commentsCount READ commentsCount NOTIFY commentsCountChanged)
 public:
     enum AlbumType {
         Album,
@@ -98,6 +100,8 @@ public:
     QString updatedTime() const;
     bool canUpload() const;
     bool liked() const;
+    int likesCount() const;
+    int commentsCount() const;
 Q_SIGNALS:
     void fromChanged();
     void nameChanged();
@@ -111,6 +115,8 @@ Q_SIGNALS:
     void updatedTimeChanged();
     void canUploadChanged();
     void likedChanged();
+    void likesCountChanged();
+    void commentsCountChanged();
 private:
     Q_DECLARE_PRIVATE(FacebookAlbumInterface)
 };

--- a/src/facebook/facebookalbuminterface_p.h
+++ b/src/facebook/facebookalbuminterface_p.h
@@ -46,6 +46,8 @@ public:
     FacebookObjectReferenceInterface *from;
     FacebookAlbumInterface::AlbumType albumType;
     bool liked;
+    int likesCount;
+    int commentsCount;
 private:
     Q_DECLARE_PUBLIC(FacebookAlbumInterface)
 };

--- a/src/facebook/facebookinterface_p.h
+++ b/src/facebook/facebookinterface_p.h
@@ -57,8 +57,6 @@ public:
     QString accessToken;
     QString currentUserIdentifier;
 
-    bool loadingSecondPartOfNodeDataRunning;
-
     QUrl requestUrl(const QString &objectId, const QString &extraPath,
                     const QStringList &whichFields, const QVariantMap &extraData);
     QNetworkReply * uploadImage(const QString &objectId, const QString &extraPath,
@@ -104,6 +102,7 @@ protected:
     virtual void handleFinished(Node &node, QNetworkReply *reply);
 
 private:
+    void setCurrentUserIdentifier(const QString &meId);
     bool startSecondPartOfNodeDataLoading(const Node &node);
     void finishSecondPartOfNodeDataLoading(Node &node, const QVariantMap &responseData);
     inline bool tryAddCacheEntryFromData(NodePrivate::Status nodeStatus,
@@ -111,8 +110,6 @@ private:
                                          const QString &requestPath, int type,
                                          const QString &typeName, QList<CacheEntry> &list,
                                          QVariantMap &nodeExtra);
-    bool performRelatedDataRequest(Node &node, const QString &identifier,
-                                   const QList<FilterInterface *> &filters);
     inline QString createField(int type, const QString &connection,
                                const RequestFieldsMap &requestFiledsMap);
     Q_DECLARE_PUBLIC(FacebookInterface)

--- a/src/facebook/facebookontology_p.h
+++ b/src/facebook/facebookontology_p.h
@@ -56,6 +56,11 @@
 #define FACEBOOK_ONTOLOGY_METADATA_PAGING_PREVIOUS         QLatin1String("previous")
 #define FACEBOOK_ONTOLOGY_METADATA_PAGING_NEXT             QLatin1String("next")
 #define FACEBOOK_ONTOLOGY_METADATA_DATA                    QLatin1String("data")
+#define FACEBOOK_ONTOLOGY_METADATA_SUMMARY                 QLatin1String("summary")
+#define FACEBOOK_ONTOLOGY_METADATA_TOTALCOUNT              QLatin1String("total_count")
+
+// Used to indicate that we are in the second phase
+#define FACEBOOK_ONTOLOGY_METADATA_SECONDPHASE             QLatin1String("second_phase")
 // >>> metadata
 
 // <<< connections

--- a/src/facebook/facebookphotointerface.h
+++ b/src/facebook/facebookphotointerface.h
@@ -75,6 +75,8 @@ class FacebookPhotoInterface: public IdentifiableContentItemInterface
     Q_PROPERTY(QString updatedTime READ updatedTime NOTIFY updatedTimeChanged)
     Q_PROPERTY(int position READ position NOTIFY positionChanged)
     Q_PROPERTY(bool liked READ liked NOTIFY likedChanged)
+    Q_PROPERTY(int likesCount READ likesCount NOTIFY likesCountChanged)
+    Q_PROPERTY(int commentsCount READ commentsCount NOTIFY commentsCountChanged)
 public:
     explicit FacebookPhotoInterface(QObject *parent = 0);
 
@@ -111,6 +113,8 @@ public:
     QString updatedTime() const;
     int position() const;
     bool liked() const;
+    int likesCount() const;
+    int commentsCount() const;
 Q_SIGNALS:
     void albumIdentifierChanged();
     void fromChanged();
@@ -129,6 +133,8 @@ Q_SIGNALS:
     void updatedTimeChanged();
     void positionChanged();
     void likedChanged();
+    void likesCountChanged();
+    void commentsCountChanged();
 private:
     Q_DECLARE_PRIVATE(FacebookPhotoInterface)
 };

--- a/src/facebook/facebookphotointerface_p.h
+++ b/src/facebook/facebookphotointerface_p.h
@@ -49,6 +49,8 @@ public:
     QList<FacebookNameTagInterface *> nameTags;
     QList<FacebookPhotoImageInterface *> images;
     bool liked;
+    int likesCount;
+    int commentsCount;
 private:
     Q_DECLARE_PUBLIC(FacebookPhotoInterface)
     static void tags_append(QDeclarativeListProperty<FacebookPhotoTagInterface> *list,

--- a/src/facebook/facebookpostinterface.h
+++ b/src/facebook/facebookpostinterface.h
@@ -82,6 +82,8 @@ class FacebookPostInterface: public IdentifiableContentItemInterface
     Q_PROPERTY(bool hidden READ hidden NOTIFY hiddenChanged)
     Q_PROPERTY(QString statusType READ statusType NOTIFY statusTypeChanged)
     Q_PROPERTY(bool liked READ liked NOTIFY likedChanged)
+    Q_PROPERTY(int likesCount READ likesCount NOTIFY likesCountChanged)
+    Q_PROPERTY(int commentsCount READ commentsCount NOTIFY commentsCountChanged)
 public:
     explicit FacebookPostInterface(QObject *parent = 0);
 
@@ -122,6 +124,8 @@ public:
     bool hidden() const;
     QString statusType() const;
     bool liked() const;
+    int likesCount() const;
+    int commentsCount() const;
 Q_SIGNALS:
     void fromChanged();
     void toChanged();
@@ -148,6 +152,8 @@ Q_SIGNALS:
     void hiddenChanged();
     void statusTypeChanged();
     void likedChanged();
+    void likesCountChanged();
+    void commentsCountChanged();
 private:
     Q_DECLARE_PRIVATE(FacebookPostInterface)
 };

--- a/src/facebook/facebookpostinterface_p.h
+++ b/src/facebook/facebookpostinterface_p.h
@@ -53,6 +53,8 @@ public:
     QList<FacebookObjectReferenceInterface *> withTags;
     FacebookObjectReferenceInterface *application;
     bool liked;
+    int likesCount;
+    int commentsCount;
 private:
     Q_DECLARE_PUBLIC(FacebookPostInterface)
     static void to_append(QDeclarativeListProperty<FacebookObjectReferenceInterface> *list,

--- a/src/socialnetworkinterface_p.h
+++ b/src/socialnetworkinterface_p.h
@@ -244,6 +244,9 @@ protected:
     void updateModelNode(Node &node);
     void updateModelRelatedData(Node &node, const QList<CacheEntry> &relatedData);
     CacheEntry createCacheEntry(const QVariantMap &data, const QString &nodeIdentifier = QString());
+
+    // Aliases map
+    QMap<QString, QString> aliases;
 private:
     // Used by NSMI
     void populate(SocialNetworkModelInterface *model, const QString &identifier,
@@ -265,7 +268,7 @@ private:
 
 
     // Implementation details
-    inline static bool matches(const Node &node, SocialNetworkModelInterface *model);
+    inline bool matches(const Node &node, SocialNetworkModelInterface *model);
     inline static SocialNetworkInterface::Status correspondingStatus(NodePrivate::Status status);
     Node getOrCreateNode(const QString &identifier, const QSet<FilterInterface *> &filters);
     Node getNode(const QString &identifier, const QSet<FilterInterface *> &filters);

--- a/src/socialnetworkmodelinterface.cpp
+++ b/src/socialnetworkmodelinterface.cpp
@@ -42,7 +42,7 @@ SocialNetworkModelInterfacePrivate::SocialNetworkModelInterfacePrivate(SocialNet
     : status(SocialNetworkInterface::Initializing)
     , error(SocialNetworkInterface::NoError)
     , socialNetwork(0)
-    , item(0), hasPrevious(false), hasNext(false)
+    , node(0), hasPrevious(false), hasNext(false)
     , resortUpdatePosted(false)
     , q_ptr(q)
 {
@@ -164,11 +164,11 @@ void SocialNetworkModelInterfacePrivate::resort()
     emit q->dataChanged(q->index(0), q->index(modelData.count() - 1));
 }
 
-void SocialNetworkModelInterfacePrivate::setItem(IdentifiableContentItemInterface *newNode)
+void SocialNetworkModelInterfacePrivate::setNode(IdentifiableContentItemInterface *newNode)
 {
     Q_Q(SocialNetworkModelInterface);
-    if (item != newNode) {
-        item = newNode;
+    if (node != newNode) {
+        node = newNode;
         emit q->nodeChanged();
     }
 }
@@ -384,7 +384,7 @@ QString SocialNetworkModelInterface::nodeIdentifier() const
 IdentifiableContentItemInterface * SocialNetworkModelInterface::node() const
 {
     Q_D(const SocialNetworkModelInterface);
-    return d->item;
+    return d->node;
 }
 
 bool SocialNetworkModelInterface::hasPrevious() const

--- a/src/socialnetworkmodelinterface_p.h
+++ b/src/socialnetworkmodelinterface_p.h
@@ -46,7 +46,7 @@ public:
 
     SocialNetworkInterface *socialNetwork;
     QString nodeIdentifier;
-    IdentifiableContentItemInterface *item;
+    IdentifiableContentItemInterface *node;
     bool hasPrevious;
     bool hasNext;
     QList<CacheEntry> modelData;
@@ -71,7 +71,7 @@ private:
     void resort();
 
     // Methods for SNI
-    void setItem(IdentifiableContentItemInterface *newNode);
+    void setNode(IdentifiableContentItemInterface *newNode);
     void clean();
     void setData(const QList<CacheEntry> &data);
     void prependData(const QList<CacheEntry> &data);

--- a/tests/socialtest/PhotoCommentsList.qml
+++ b/tests/socialtest/PhotoCommentsList.qml
@@ -60,7 +60,9 @@ Item {
         id: topLabel
         anchors.top: parent.top
         anchors.horizontalCenter: parent.horizontalCenter
-        text: "There are " + model.count + " comments on this photo"
+        text: model.node == null ? "... Loading ..."
+              : "Comments: " + (model.node.commentsCount == -1 ? "..." : model.node.commentsCount)
+              + "\nLikes: " + (model.node.likesCount == -1 ? "..." : model.node.likesCount)
     }
 
     Column {

--- a/tests/socialtest/PhotosGrid.qml
+++ b/tests/socialtest/PhotosGrid.qml
@@ -58,7 +58,10 @@ Item {
         id: topLabel
         anchors.top: parent.top
         anchors.horizontalCenter: parent.horizontalCenter
-        text: "You have " + model.count + " photos in this album"
+        text: model.node == null ? "... Loading ..."
+              : "There are "  + model.node.count + " photos in this album"
+              + "\nComments: " + (model.node.commentsCount == -1 ? "..." : model.node.commentsCount)
+              + "\nLikes: " + (model.node.likesCount == -1 ? "..." : model.node.likesCount)
     }
 
     Button {

--- a/tests/socialtest/PostCommentsList.qml
+++ b/tests/socialtest/PostCommentsList.qml
@@ -35,8 +35,14 @@ import org.nemomobile.social 1.0
 Item {
     id: root
     anchors.fill: parent
+    property string currentIdentifier
     signal backClicked
     function populate(nodeId) {
+        if (currentIdentifier == nodeId) {
+            model.repopulate()
+            return
+        }
+
         model.nodeIdentifier = nodeId
         model.populate()
         view.positionViewAtBeginning()
@@ -52,7 +58,9 @@ Item {
         id: topLabel
         anchors.top: parent.top
         anchors.horizontalCenter: parent.horizontalCenter
-        text: "There are " + model.count + " comments on this post"
+        text: model.node == null ? "... Loading ..."
+              : "Comments: " + (model.node.commentsCount == -1 ? "..." : model.node.commentsCount)
+              + "\nLikes: " + (model.node.likesCount == -1 ? "..." : model.node.likesCount)
     }
 
     Button {
@@ -74,8 +82,9 @@ Item {
         delegate: Item {
             id: commentDelegate
             width: parent.width
-            height: childrenRect.height + 20
+            height: column.height + 20
             Column {
+                id: column
                 anchors.left: parent.left; anchors.leftMargin: 10
                 anchors.right: parent.right; anchors.rightMargin: 10
                 anchors.verticalCenter: parent.verticalCenter

--- a/tests/socialtest/qt5ify.sh
+++ b/tests/socialtest/qt5ify.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-mkdir qt5
+if [ ! -d qt5 ]; then
+    mkdir qt5
+fi
 
 for qml in `ls *.qml`; do
     sed 's|import QtQuick 1.*|import QtQuick 2.0|g' < $qml > qt5/$qml

--- a/tests/socialtest/socialtest.qml
+++ b/tests/socialtest/socialtest.qml
@@ -194,7 +194,7 @@ Item {
                     if (model.which == -1) {
                         Qt.quit()
                     } else if (model.which == -2) {
-                        if(portraitModel.status == Facebook.Initializing) {
+                        if(!portraitModel.retrieved) {
                             portraitModel.populate()
                             root.whichActive = -1
                         } else {
@@ -290,6 +290,7 @@ Item {
 
     SocialNetworkModel {
         id: portraitModel
+        property bool retrieved: false
         function displayPortraitUrl() {
             console.debug("User picture: " + portraitModel.node.picture.url)
         }
@@ -301,6 +302,7 @@ Item {
             if (status == Facebook.Idle) {
                 displayPortraitUrl()
                 root.whichActive = 0
+                portraitModel.retrieved = true
             }
         }
     }

--- a/tools/album.json
+++ b/tools/album.json
@@ -67,6 +67,20 @@
             "custom": true,
             "is_ontology": false,
             "doc": "Whether the album has been liked by the current user."
+        },
+        {
+            "name": "likes_count",
+            "type": "int",
+            "custom": true,
+            "is_ontology": false,
+            "doc": "The number of likes on this album."
+        },
+        {
+            "name": "comments_count",
+            "type": "int",
+            "custom": true,
+            "is_ontology": false,
+            "doc": "The number of likes on this album."
         }
     ],
     "methods": [

--- a/tools/photo.json
+++ b/tools/photo.json
@@ -94,6 +94,20 @@
             "custom": true,
             "is_ontology": false,
             "doc": "Whether the photo has been liked by the current user."
+        },
+        {
+            "name": "likes_count",
+            "type": "int",
+            "custom": true,
+            "is_ontology": false,
+            "doc": "The number of likes on this photo."
+        },
+        {
+            "name": "comments_count",
+            "type": "int",
+            "custom": true,
+            "is_ontology": false,
+            "doc": "The number of likes on this photo."
         }
     ],
     "methods": [

--- a/tools/post.json
+++ b/tools/post.json
@@ -168,6 +168,20 @@
             "custom": true,
             "is_ontology": false,
             "doc": "Whether the post has been liked by the current user."
+        },
+        {
+            "name": "likes_count",
+            "type": "int",
+            "custom": true,
+            "is_ontology": false,
+            "doc": "The number of likes on this post."
+        },
+        {
+            "name": "comments_count",
+            "type": "int",
+            "custom": true,
+            "is_ontology": false,
+            "doc": "The number of likes on this post."
         }
     ],
     "methods": [


### PR DESCRIPTION
This commit brings (backà the capability to retrieve the
number of likes and comments that was posted in a Post, Album or
Photo. It was removed because of a Facbeook API change.

It also fixes some bugs, notably the one making picture of
"me" impossible to load in the demo application. This fix
is done by introducing the "alias" map in SNIp. Comparison
between nodes and models takes aliases of the identifier
in consideration (like the one between "me" and the actual
identifier in Facebook).

The UserPicture loading is also being cleaner, and now
use related data method to load, making reloading of only
this component possible (fixing another bug).

The last bug that was fixed is the capability to store the
type that was guessed, and do not have to guess it again.

It also fixes the small warning that happens when running qmake
in the test folder in Qt5 (because the qt5 folder often exists).
