### PR TITLE
[feature] Add support for status updating posting

### DIFF
--- a/src/facebook/facebookinterface_p.h
+++ b/src/facebook/facebookinterface_p.h
@@ -66,7 +66,9 @@ public:
         UploadPhotoAction,
         DeletePhotoAction,
         UploadAlbumAction,
-        DeleteAlbumAction
+        DeleteAlbumAction,
+        UploadPostAction,
+        DeletePostAction
     };
 
     explicit FacebookInterfacePrivate(FacebookInterface *q);

--- a/src/facebook/facebookuserinterface.h
+++ b/src/facebook/facebookuserinterface.h
@@ -114,6 +114,8 @@ public:
     Q_INVOKABLE bool removePhoto(const QString &photoIdentifier);
     Q_INVOKABLE bool uploadAlbum(const QString &name, const QString &message = QString(), const QVariantMap &privacy = QVariantMap());
     Q_INVOKABLE bool removeAlbum(const QString &albumIdentifier);
+    Q_INVOKABLE bool uploadStatus(const QString &message);
+    Q_INVOKABLE bool removeStatus(const QString &statusIdentifier);
 
     // Accessors
     QString name() const;

--- a/tests/socialtest/ButtonBackground.qml
+++ b/tests/socialtest/ButtonBackground.qml
@@ -34,13 +34,22 @@ import QtQuick 1.1
 Rectangle {
     id: container
     signal clicked()
+    signal rightClicked()
+
     width: 200
     height: 60
     color: !mouseArea.pressed ? "white" : "#DCDCDC"
 
     MouseArea {
         id: mouseArea
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
         anchors.fill: parent
-        onClicked: container.clicked()
+        onClicked: {
+            if (mouse.button == Qt.LeftButton) {
+                container.clicked()
+            } else {
+                container.rightClicked()
+            }
+        }
     }
 }

--- a/tests/socialtest/PostList.qml
+++ b/tests/socialtest/PostList.qml
@@ -85,6 +85,10 @@ Item {
             width: view.width
             height: column.height + 20
             onClicked: container.postClicked(model.contentItem.identifier)
+            onRightClicked: {
+                menuContainer.postIdentifier = model.contentItem.identifier
+                menuContainer.visible = true
+            }
             Column {
                 id: column
                 property string message: model.contentItem.message
@@ -105,4 +109,48 @@ Item {
             }
         }
     }
+
+    Item {
+        id: menuContainer
+        anchors.fill: parent
+        property string postIdentifier
+        property bool loading: false
+        visible: false
+
+        Connections {
+            target: model.node
+            onStatusChanged: {
+                if (model.node.status == Facebook.Idle) {
+                    menuContainer.loading = false
+                    menuContainer.visible = false
+                    model.repopulate()
+                }
+            }
+        }
+
+        Rectangle {
+            anchors.fill: parent
+            color: "grey"
+            opacity: 0.5
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            enabled: menuContainer.visible
+            onClicked: menuContainer.visible = false
+        }
+
+        Column {
+            anchors.centerIn: parent
+            Button {
+                enabled: menuContainer.visible && !menuContainer.loading
+                text: "Remove"
+                onClicked: {
+                    menuContainer.loading = true
+                    model.node.removeStatus(menuContainer.postIdentifier)
+                }
+            }
+        }
+    } 
+
 }

--- a/tests/socialtest/socialtest.qml
+++ b/tests/socialtest/socialtest.qml
@@ -184,7 +184,10 @@ Item {
                 text: "Test getting \"me\""
                 which: -4
             }
-
+            ListElement {
+                text: "Test posting something"
+                which: -5
+            }
             ListElement {
                 text: "Quit"
                 which: -1
@@ -203,7 +206,7 @@ Item {
                     } else if (model.which == -2) {
                         if(!portraitModel.retrieved) {
                             portraitModel.populate()
-                            root.whichActive = -1
+                            root.whichActive = -2
                         } else {
                             portraitModel.displayPortraitUrl()
                         }
@@ -212,7 +215,6 @@ Item {
                             user.displayUser()
                             return
                         }
-
                         root.whichActive = -3
                         user.identifier = "me"
                     } else if(model.which == -4) {
@@ -220,6 +222,14 @@ Item {
                             root.whichActive = -4
                             nsuffysModel.populate()
                         }
+                    } else if (model.which == -5) {
+                        if (postingUser.identifier == "me" || postingUser.status != Facebook.Idle) {
+                            console.debug("Please retrieve the current user first")
+                            return
+                        }
+                        root.whichActive = -5
+                        postingUser.posting = true
+                        postingUser.uploadStatus("Hello everybody ! How are you ?")
                     } else {
                         makeActive(model.which, facebook.currentUserIdentifier)
                     }
@@ -357,6 +367,19 @@ Item {
                 console.debug("Test user retrieved: " + nsuffysModel.node.name)
                 nsuffysModel.retrieved = true
                 root.whichActive = 0
+            }
+        }
+    }
+
+    FacebookUser {
+        id: postingUser
+        socialNetwork: facebook
+        property bool posting: false
+        identifier: facebook.currentUserIdentifier
+        onStatusChanged: {
+            if (status == Facebook.Idle && posting) {
+                root.whichActive = 0
+                posting = false
             }
         }
     }

--- a/tools/user.json
+++ b/tools/user.json
@@ -167,7 +167,7 @@
                     "is_reference": true
                 }
             ],
-            "doc": "Initiates a \"post photo\" operation on the user.  The photo will\nbe loaded from the local filesystem and uploaded to Facebook with\nits caption set to the given \\a message. It will be uploaded to\nthe default album of the user.\n\nIf the network request was started successfully, the function\nwill return true and the status of the user will change to\n\\c SocialNetwork::Busy.  Otherwise, the function will return\nfalse.\n\nOnce the network request completes, the \\c responseReceived()\nsignal will be emitted.  The \\c data parameter of the signal\nwill contain the \\c id of the newly uploaded photo.\n"
+            "doc": "Initiates a \"post photo\" operation on the user.  The photo will\nbe loaded from the local filesystem and uploaded to Facebook with\nits caption set to the given \\a message. It will be uploaded to\nthe default album of the user.\n\nIf the network request was started successfully, the function\nwill return true and the status of the user will change to\n\\c SocialNetwork::Busy.  Otherwise, the function will return\nfalse.\n\nOnce the network request completes, the \\c responseReceived()\nsignal will be emitted.  The \\c data parameter of the signal\nwill contain the \\c id of the newly uploaded photo."
         },
         {
             "name": "removePhoto",
@@ -218,6 +218,30 @@
                 }
             ],
             "doc": "Initiates a \"delete album\" operation on the album specified by\nthe given \\a identifier.\n\nIf the network request was started successfully, the function\nwill return true and the status of the user will change to\n\\c SocialNetwork::Busy.  Otherwise, the function will return\nfalse."
+        },
+        {
+            "name": "uploadStatus",
+            "parameters": [
+                {
+                    "type": "QString",
+                    "name": "message",
+                    "is_const": true,
+                    "is_reference": true
+                }
+            ],
+            "doc": "Initiates a \"post status\" operation on the user.  The status\nwill contain the message provided by \\a message, and will be\nposted as a status update.\n\nwill return true and the status of the user will change to\n\\c SocialNetwork::Busy.  Otherwise, the function will return\nfalse.\n\nOnce the network request completes, the \\c responseReceived()\nsignal will be emitted.  The \\c data parameter of the signal\nwill contain the \\c id of the newly uploaded status."
+        },
+        {
+            "name": "removeStatus",
+            "parameters": [
+                {
+                    "type": "QString",
+                    "name": "statusIdentifier",
+                    "is_const": true,
+                    "is_reference": true
+                }
+            ],
+            "doc": "Initiates a \"delete status\" operation on the status specified by\nthe given \\a identifier.\n\nIf the network request was started successfully, the function\nwill return true and the status of the user will change to\n\\c SocialNetwork::Busy.  Otherwise, the function will return\nfalse."
         }
     ]
 }


### PR DESCRIPTION
This commit adds two methods for FacebookUser:
uploadStatus and deleteStatus. These methods
are used to create and remove statuses.
