### PR TITLE
[fix] Uses shared pointers instead of explicitely shared objects

### DIFF
--- a/src/facebook/facebookinterface_p.h
+++ b/src/facebook/facebookinterface_p.h
@@ -75,9 +75,9 @@ public:
     QString currentUserIdentifier;
 protected:
     // Reimplemented
-    void populateDataForNode(Node &node);
-    void populateRelatedDataforNode(Node &node);
-    bool validateCacheEntryForNode(const CacheEntry &cacheEntry);
+    void populateDataForNode(Node::Ptr node);
+    void populateRelatedDataforNode(Node::Ptr node);
+    bool validateCacheEntryForNode(CacheEntry::ConstPtr cacheEntry);
     QString dataSection(int type, const QVariantMap &data) const;
     ContentItemInterface * contentItemFromData(const QVariantMap &data, QObject *parent = 0) const;
     QNetworkReply * getRequest(const QString &objectIdentifier, const QString &extraPath,
@@ -86,23 +86,23 @@ protected:
                                 const QVariantMap &data, const QVariantMap &extraData);
     QNetworkReply * deleteRequest(const QString &objectIdentifier, const QString &extraPath,
                                   const QVariantMap &extraData);
-    void handleFinished(Node &node, QNetworkReply *reply);
+    void handleFinished(Node::Ptr node, QNetworkReply *reply);
 
 private:
     QUrl requestUrl(const QString &objectId, const QString &extraPath,
                     const QStringList &whichFields, const QVariantMap &extraData);
     QNetworkReply * uploadImage(const QString &objectId, const QString &extraPath,
                                 const QVariantMap &data, const QVariantMap &extraData);
-    void handlePopulateNode(Node &node, const QVariantMap &responseData);
-    void handlePopulateRelatedData(Node &node, const QVariantMap &relatedData,
+    void handlePopulateNode(Node::Ptr node, const QVariantMap &responseData);
+    void handlePopulateRelatedData(Node::Ptr node, const QVariantMap &relatedData,
                                    const QUrl &requestUrl);
     void setCurrentUserIdentifier(const QString &meId);
-    bool checkNodeType(Node &node);
-    bool checkIfNeedAdditionalLoading(Node &node);
+    bool checkNodeType(Node::Ptr node);
+    bool checkIfNeedAdditionalLoading(Node::Ptr node);
     inline bool tryAddCacheEntryFromData(NodePrivate::Status nodeStatus,
                                          const QVariantMap &relatedData,
                                          const QString &requestPath, int type,
-                                         const QString &typeName, QList<CacheEntry> &list,
+                                         const QString &typeName, CacheEntry::List &list,
                                          QVariantMap &nodeExtra);
     inline QString createField(int type, const QString &connection,
                                const RequestFieldsMap &requestFiledsMap);

--- a/src/socialnetworkmodelinterface.cpp
+++ b/src/socialnetworkmodelinterface.cpp
@@ -193,7 +193,7 @@ void SocialNetworkModelInterfacePrivate::clean()
     setHavePreviousAndNext(false, false);
 }
 
-void SocialNetworkModelInterfacePrivate::setData(const QList<CacheEntry> &data)
+void SocialNetworkModelInterfacePrivate::setData(const CacheEntry::List &data)
 {
     Q_Q(SocialNetworkModelInterface);
     if (data.isEmpty()) {
@@ -211,7 +211,7 @@ void SocialNetworkModelInterfacePrivate::setData(const QList<CacheEntry> &data)
     resort();
 }
 
-void SocialNetworkModelInterfacePrivate::prependData(const QList<CacheEntry> &data)
+void SocialNetworkModelInterfacePrivate::prependData(const CacheEntry::List &data)
 {
     Q_Q(SocialNetworkModelInterface);
     if (data.isEmpty()) {
@@ -219,7 +219,7 @@ void SocialNetworkModelInterfacePrivate::prependData(const QList<CacheEntry> &da
     }
 
     q->beginInsertRows(QModelIndex(), 0, data.count() - 1);
-    QList<CacheEntry> newData = data;
+    CacheEntry::List newData = data;
     newData.append(modelData);
     modelData = newData;
     emit q->countChanged();
@@ -227,7 +227,7 @@ void SocialNetworkModelInterfacePrivate::prependData(const QList<CacheEntry> &da
     resort();
 }
 
-void SocialNetworkModelInterfacePrivate::appendData(const QList<CacheEntry> &data)
+void SocialNetworkModelInterfacePrivate::appendData(const CacheEntry::List &data)
 {
     Q_Q(SocialNetworkModelInterface);
     if (data.isEmpty()) {
@@ -327,28 +327,28 @@ QVariant SocialNetworkModelInterface::data(const QModelIndex &index, int role) c
         return QVariant();
     }
 
-    CacheEntry cacheEntry = d->modelData.at(index.row());
+    CacheEntry::Ptr cacheEntry = d->modelData.at(index.row());
 
     switch (role) {
         case ContentItemTypeRole: {
-            return QVariant::fromValue(cacheEntry.data().value(NEMOQMLPLUGINS_SOCIAL_CONTENTITEMTYPE).toInt());
+            return QVariant::fromValue(cacheEntry->data().value(NEMOQMLPLUGINS_SOCIAL_CONTENTITEMTYPE).toInt());
         }
         case ContentItemDataRole: {
-            return QVariant::fromValue(cacheEntry.data());
+            return QVariant::fromValue(cacheEntry->data());
         }
         case ContentItemIdentifierRole: {
-            return QVariant::fromValue(cacheEntry.data().value(NEMOQMLPLUGINS_SOCIAL_CONTENTITEMID).toString());
+            return QVariant::fromValue(cacheEntry->data().value(NEMOQMLPLUGINS_SOCIAL_CONTENTITEMID).toString());
         }
         case ContentItemRole: {
-            if (cacheEntry.item()) {
-                return QVariant::fromValue(cacheEntry.item());
+            if (cacheEntry->item()) {
+                return QVariant::fromValue(cacheEntry->item());
             }
 
             return QVariant::fromValue(d->socialNetwork->d_func()->createItem(cacheEntry));
         }
         case SectionRole: {
-            return d->socialNetwork->d_func()->dataSection(cacheEntry.data().value(NEMOQMLPLUGINS_SOCIAL_CONTENTITEMTYPE).toInt(),
-                                                           cacheEntry.data());
+            return d->socialNetwork->d_func()->dataSection(cacheEntry->data().value(NEMOQMLPLUGINS_SOCIAL_CONTENTITEMTYPE).toInt(),
+                                                           cacheEntry->data());
         }
         default: {
             return QVariant();

--- a/src/socialnetworkmodelinterface_p.h
+++ b/src/socialnetworkmodelinterface_p.h
@@ -51,7 +51,7 @@ public:
     IdentifiableContentItemInterface *node;
     bool hasPrevious;
     bool hasNext;
-    QList<CacheEntry> modelData;
+    CacheEntry::List modelData;
     bool resortUpdatePosted;
 private:
     void init();
@@ -75,9 +75,9 @@ private:
     // Methods for SNI
     void setNode(IdentifiableContentItemInterface *newNode);
     void clean();
-    void setData(const QList<CacheEntry> &data);
-    void prependData(const QList<CacheEntry> &data);
-    void appendData(const QList<CacheEntry> &data);
+    void setData(const CacheEntry::List &data);
+    void prependData(const CacheEntry::List &data);
+    void appendData(const CacheEntry::List &data);
     void setStatus(SocialNetworkInterface::Status newStatus);
     void setError(SocialNetworkInterface::ErrorType newError, const QString &newErrorMessage);
     void setHavePreviousAndNext(bool newHasPrevious, bool newHasNext);

--- a/src/twitter/twitterinterface_p.h
+++ b/src/twitter/twitterinterface_p.h
@@ -71,7 +71,7 @@ public:
                                    const QVariantMap &postData = QVariantMap());
 
     int detectTypeFromData(const QVariantMap &data) const;
-    void handlePopulateRelatedData(Node &node, const QVariant &relatedData,
+    void handlePopulateRelatedData(Node::Ptr node, const QVariant &relatedData,
                                    const QUrl &requestUrl);
 
     // Requests
@@ -92,8 +92,8 @@ public:
     };
 protected:
     // Reimplemented
-    void populateDataForNode(Node &node);
-    void populateRelatedDataforNode(Node &node);
+    void populateDataForNode(Node::Ptr node);
+    void populateRelatedDataforNode(Node::Ptr node);
     bool validateCacheEntryForNode(const CacheEntry &cacheEntry);
     QString dataSection(int type, const QVariantMap &data) const;
     ContentItemInterface * contentItemFromData(const QVariantMap &data, QObject *parent = 0) const;
@@ -104,10 +104,10 @@ protected:
     QNetworkReply * deleteRequest(const QString &objectIdentifier, const QString &extraPath,
                                   const QVariantMap &extraData);
     int guessType(const QString &identifier, int type, const QSet<FilterInterface *> &filters);
-    void handleFinished(Node &node, QNetworkReply *reply);
+    void handleFinished(Node::Ptr node, QNetworkReply *reply);
 
 private:
-    bool performRelatedDataRequest(Node &node, const QString &identifier,
+    bool performRelatedDataRequest(Node::Ptr node, const QString &identifier,
                                    const QList<FilterInterface *> &filters);
     Q_DECLARE_PUBLIC(TwitterInterface)
 };

--- a/tests/facebooksocialtest/facebooksocialtest.qml
+++ b/tests/facebooksocialtest/facebooksocialtest.qml
@@ -240,7 +240,7 @@ Item {
         ]
     }
 
-    PostList {
+    FacebookPostList {
         id: homeList
         visible: whichActive == 11
         onBackClicked: back(0)


### PR DESCRIPTION
Shared pointers at least reflect the syntax of a pointer,
so Node and CacheEntry are now migrated to QSharedPointer,
instead of the old and dirty explicitely shared objects.

There is also a quick fix for one test included.
