### PR TITLE
[bugfix] Fix for Twitter favoriting operation

### DIFF
--- a/src/facebook/facebookinterface.cpp
+++ b/src/facebook/facebookinterface.cpp
@@ -180,7 +180,9 @@ void FacebookInterfacePrivate::populateRelatedDataforNode(Node::Ptr node)
 
         int type = -1;
         if (contentItemTypeFilter) {
-            // We ignore also all redundant filters
+            // We only use the first filter of a given type to
+            // build the request. So we ignore all the following filters
+            // of the same type
             type = contentItemTypeFilter->type();
             if (!connectionTypes.contains(type)) {
                 connectionTypes.append(type);
@@ -200,7 +202,7 @@ void FacebookInterfacePrivate::populateRelatedDataforNode(Node::Ptr node)
 
         if (facebookCommentFilterInterface) {
             type = FacebookInterface::Comment;
-            // Still ignoring any redundant filter
+            // Just like before, we ignore redundant filter
             // especially a "Comment" type ContentItemTypeFilterInterface
             if (!connectionTypes.contains(type)) {
                 connectionTypes.append(type);

--- a/src/twitter/twittertweetinterface.cpp
+++ b/src/twitter/twittertweetinterface.cpp
@@ -86,12 +86,21 @@ void TwitterTweetInterfacePrivate::finishedHandler()
         break;
         case TwitterInterfacePrivate::UnfavoriteAction:
         case TwitterInterfacePrivate::FavoriteAction: {
+
             // Update the favorited count
             bool favorited = responseData.value(TWITTER_ONTOLOGY_TWEET_FAVORITED).toBool();
-            int favoriteCount = responseData.value(TWITTER_ONTOLOGY_TWEET_FAVORITECOUNT).toInt();
             QVariantMap currentData = data();
-            currentData.insert(TWITTER_ONTOLOGY_TWEET_FAVORITED, QVariant::fromValue(favorited));
+            int favoriteCount = currentData.value(TWITTER_ONTOLOGY_TWEET_FAVORITECOUNT).toInt();
+            // We need to overcome a Twitter bug (or feature) that when returning from
+            // favorites/create, the "favorite_count" field is null. So, as a hack, we
+            // just increment (or decrement) the current favorite count.
+            if (action == TwitterInterfacePrivate::UnfavoriteAction) {
+                favoriteCount = qMax(0, favoriteCount - 1);
+            } else if (action == TwitterInterfacePrivate::FavoriteAction) {
+                ++ favoriteCount;
+            }
             currentData.insert(TWITTER_ONTOLOGY_TWEET_FAVORITECOUNT, favoriteCount);
+            currentData.insert(TWITTER_ONTOLOGY_TWEET_FAVORITED, QVariant::fromValue(favorited));
             setData(currentData);
             emit q->favoritedChanged();
             emit q->favoriteCountChanged();


### PR DESCRIPTION
Because Twitter don't report the number of favorites
when doing a favoriting, we have to update the number
of favorites manually.
