### PR TITLE
[bugfix] Prevent a crash when SNI got destroyed

### DIFF
--- a/src/socialnetworkinterface.cpp
+++ b/src/socialnetworkinterface.cpp
@@ -1587,13 +1587,18 @@ void SocialNetworkInterfacePrivate::deleteNode(Node::Ptr node)
         }
     }
 
-    node->cacheEntry()->deref();
+    if (!node->cacheEntry().isNull()) {
+        node->cacheEntry()->deref();
+    }
 
     foreach (CacheEntry::Ptr entry, node->relatedData()) {
         entry->deref();
     }
 
-    checkCacheEntryRefcount(node->cacheEntry());
+    if (!node->cacheEntry().isNull()) {
+        checkCacheEntryRefcount(node->cacheEntry());
+    }
+
     foreach (CacheEntry::Ptr entry, node->relatedData()) {
         checkCacheEntryRefcount(entry);
     }


### PR DESCRIPTION
The crash happens when a Node that have a null CacheEntry
got destroyed. If this happens, the destructor will still
check if we should deref and clear the null CacheEntry, and
will crash.

Now, the check is only made when the CacheEntry is not null.
