### PR TITLE
[feature] Workaround for removing retweets

### DIFF
--- a/src/identifiablecontentiteminterface.cpp
+++ b/src/identifiablecontentiteminterface.cpp
@@ -61,6 +61,7 @@ QNetworkReply *IdentifiableContentItemInterfacePrivate::reply()
 void IdentifiableContentItemInterfacePrivate::deleteReply()
 {
     if (currentReply) {
+        currentReply->disconnect();
         currentReply->deleteLater();
         currentReply = 0;
     }

--- a/src/twitter/twitterinterface_p.h
+++ b/src/twitter/twitterinterface_p.h
@@ -89,6 +89,8 @@ public:
         UnfollowAction,
         TweetAction,
         RetweetAction,
+        UnretweetGetTweetIdToRemoveAction,
+        UnretweetRemoveTweetAction,
         FavoriteAction,
         UnfavoriteAction
     };

--- a/src/twitter/twitterontology_p.h
+++ b/src/twitter/twitterontology_p.h
@@ -160,6 +160,7 @@
 #define TWITTER_ONTOLOGY_CONNECTION_EXCLUDE_REPLIES_KEY             QLatin1String("exclude_replies")
 #define TWITTER_ONTOLOGY_CONNECTION_CONTRIBUTOR_DETAILS_KEY         QLatin1String("contributor_details")
 #define TWITTER_ONTOLOGY_CONNECTION_COUNT_KEY                       QLatin1String("count")
+#define TWITTER_ONTOLOGY_CONNECTION_INCLUDE_RTS_KEY                 QLatin1String("include_rts")
 
 
 #define TWITTER_ONTOLOGY_CONNECTION_USERS_KEY                       QLatin1String("users")
@@ -195,6 +196,7 @@
 #define TWITTER_ONTOLOGY_CONNECTION_STATUS_UPDATE_IN_REPLY_TO_STATUS_ID_KEY QLatin1String("in_reply_to_status_id")
 // More to come here (lat long etc)
 #define TWITTER_ONTOLOGY_CONNECTION_STATUS_RETWEET                  QLatin1String("statuses/retweet/%1.json")
+#define TWITTER_ONTOLOGY_CONNECTION_STATUS_DESTROY                  QLatin1String("statuses/destroy/%1.json")
 
 #define TWITTER_ONTOLOGY_CONNECTION_FAVORITES_CREATE                QLatin1String("favorites/create.json")
 #define TWITTER_ONTOLOGY_CONNECTION_FAVORITES_DESTROY               QLatin1String("favorites/destroy.json")

--- a/src/twitter/twittertweetinterface.h
+++ b/src/twitter/twittertweetinterface.h
@@ -75,6 +75,7 @@ public:
 
     // Invokable API.
     Q_INVOKABLE bool uploadRetweet();
+    Q_INVOKABLE bool removeRetweet();
     Q_INVOKABLE bool favorite();
     Q_INVOKABLE bool unfavorite();
     Q_INVOKABLE bool uploadReply(const QString &message, const QStringList &pathToMedias = QStringList());

--- a/tests/twittersocialtest/TwitterRetweetPage.qml
+++ b/tests/twittersocialtest/TwitterRetweetPage.qml
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2013 Jolla Ltd. <chris.adams@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+import QtQuick 1.1
+import org.nemomobile.social 1.0
+
+Item {
+    id: container
+    anchors.fill: parent
+    signal backClicked
+
+    TwitterTweet {
+        id: tweet
+        socialNetwork: twitter
+    }
+
+    Column {
+        id: header
+        anchors.top: parent.top; anchors.left: parent.left; anchors.right: parent.right
+
+        Item {
+            anchors.left: parent.left; anchors.right: parent.right
+            height: input.height
+
+            Rectangle {
+                anchors.fill: input
+                color: "#CCCCCC"
+            }
+            TextInput {
+                id: input
+                height: 50
+                anchors.left: parent.left; anchors.right: parent.right
+                font.pixelSize: 50
+            }
+        }
+
+        Text {
+            id: tweetStatus
+            function setText() {
+                switch (tweet.status) {
+                case SocialNetwork.Idle:
+                    if (tweet.identifier == "") {
+                        text = "Tweet invalid"
+                        break
+                    }
+                    text = "Tweet ready"
+                    break
+                case SocialNetwork.Busy:
+                    text = "Tweet busy"
+                    break
+                case SocialNetwork.Error:
+                    text = "Tweet error"
+                    break
+                default:
+                    text = ""
+                    break
+                }
+            }
+
+            anchors.horizontalCenter: parent.horizontalCenter
+
+            Connections {
+                target: tweet
+                onStatusChanged: tweetStatus.setText()
+            }
+        }
+
+        TwitterButton {
+            anchors.horizontalCenter: parent.horizontalCenter
+            text: "Load tweet"
+            onClicked: {
+                if (tweet.identifier != input.text) {
+                    tweet.identifier = input.text
+                } else {
+                    tweet.reload()
+                }
+            }
+        }
+
+        TwitterButton {
+            anchors.horizontalCenter: parent.horizontalCenter
+            enabled: tweet.status == SocialNetwork.Idle && tweet.identifier != ""
+            text: enabled ? (tweet.retweeted ? "Cancel Retweet" : "Retweet") : ""
+            onClicked: {
+                if (!tweet.retweeted) {
+                    tweet.uploadRetweet()
+                } else {
+                    tweet.removeRetweet()
+                }
+            }
+        }
+    }
+
+    TwitterButton {
+        id: backButton
+        anchors.bottom: parent.bottom
+        anchors.horizontalCenter: parent.horizontalCenter
+        text: "Back"
+        onClicked: container.backClicked()
+    }
+}

--- a/tests/twittersocialtest/twittersocialtest.qml
+++ b/tests/twittersocialtest/twittersocialtest.qml
@@ -163,6 +163,10 @@ Item {
                 which: 6
             }
             ListElement {
+                text: "Show retweet test"
+                which: -5
+            }
+            ListElement {
                 text: "Quit"
                 which: -1
             }
@@ -237,6 +241,12 @@ Item {
         id: replyList
         visible: whichActive == 6
         filters: [twitter.replyFilter]
+        onBackClicked: back(0)
+    }
+
+    TwitterRetweetPage {
+        id: retweetPage
+        visible: whichActive == -5
         onBackClicked: back(0)
     }
 }

--- a/tools/twitter/tweet.json
+++ b/tools/twitter/tweet.json
@@ -159,6 +159,11 @@
             "doc": ""
         },
         {
+            "name": "removeRetweet",
+            "parameters": [],
+            "doc": ""
+        },
+        {
             "name": "favorite",
             "parameters": [],
             "doc": ""


### PR DESCRIPTION
The workaround consists of getting the latest tweets someone
made and then search for the retweet inside them. If it cannot
be found, there will be a failure in removing the RT.

After removing a RT, there might be some error while retweeting
again right after (maybe because Twitter think that you still
have the tweet in the timeline, and prevent you to re-retweet
directly). It is something rather unpredictible and impossible
to prevent.
