### PR TITLE
[bugfix] Prevent crash if SNI is destroyed and SNMI being destroyed too

### DIFF
--- a/src/socialnetworkinterface.cpp
+++ b/src/socialnetworkinterface.cpp
@@ -721,7 +721,6 @@ SocialNetworkInterfacePrivate::~SocialNetworkInterfacePrivate()
     // We should say to all models that we are being destroyed
     foreach (SocialNetworkModelInterface *model, models) {
         model->d_func()->setNode(0);
-        model->d_func()->clean();
     }
 
     // Remove all nodes


### PR DESCRIPTION
This commit prevents a crash if SNI is destroyed where SNMI is
destroyed too. If we call QALM::endRemoveRows() while the view
is being destroyed, it might lead to some double free (item models
are being removed first by the view and again by the model). If we
don't clean when deleting the SNI, we cover most user-case and
prevent this crash.

The only issue that can happen is that we keep the SNMI and
destroys the SNI. Then, data in the SNMI would stay. It is
not really nice, but shold be so rare that we can discard
this case.
