### PR TITLE
[bugfix] Fixes segmentation fault

### DIFF
--- a/src/socialnetworkinterface.cpp
+++ b/src/socialnetworkinterface.cpp
@@ -721,6 +721,7 @@ SocialNetworkInterfacePrivate::~SocialNetworkInterfacePrivate()
     // We should say to all models that we are being destroyed
     foreach (SocialNetworkModelInterface *model, models) {
         model->d_func()->setNode(0);
+        model->d_func()->modelData.clear();
     }
 
     // Remove all nodes


### PR DESCRIPTION
This commit partially reverts the previous commit.
Now instead of clearing data from the models using
clean(), it just clear the list of data, without
calling beginRemoveRows and endRemoveRows.
