### PR TITLE
[nemo-qml-plugin-social] Fixed a dangling pointer crash in SocialNetwork...

### DIFF
--- a/src/socialnetworkmodelinterface.cpp
+++ b/src/socialnetworkmodelinterface.cpp
@@ -452,7 +452,9 @@ void SocialNetworkModelInterface::setSocialNetwork(SocialNetworkInterface *socia
         }
 
         d->socialNetwork = socialNetwork;
-        d->socialNetwork->d_func()->addModel(this);
+        if (d->socialNetwork) {
+            d->socialNetwork->d_func()->addModel(this);
+        }
         emit socialNetworkChanged();
     }
 }

--- a/src/socialnetworkmodelinterface_p.h
+++ b/src/socialnetworkmodelinterface_p.h
@@ -45,7 +45,7 @@ public:
     SocialNetworkInterface::ErrorType error;
     QString errorMessage;
 
-    SocialNetworkInterface *socialNetwork;
+    QPointer<SocialNetworkInterface> socialNetwork;
     QString nodeIdentifier;
     int nodeType;
     IdentifiableContentItemInterface *node;


### PR DESCRIPTION
...ModelInterface

Encountered a case where UI destroys SocialNetwork instance before attached
SocialNetworkModelInterface instances. This leaves socialNetwork
pointer dangling and in our case caused a crash because later parts
of the destructor chain tried to access said pointer.
Fixed by wrapping the pointer inside QPointer.