### PR TITLE
[nemo-qml-plugin-social] Parse Facebook replies correctly

### DIFF
--- a/src/facebook/facebookalbuminterface.cpp
+++ b/src/facebook/facebookalbuminterface.cpp
@@ -71,7 +71,7 @@ void FacebookAlbumInterfacePrivate::finishedHandler()
         case FacebookInterfacePrivate::DeleteLikeAction:  // flow down.
         case FacebookInterfacePrivate::DeletePhotoAction: // flow down.
         case FacebookInterfacePrivate::DeleteCommentAction: {
-            if (replyData == QString(QLatin1String("true"))) {
+            if (responseData.value(QLatin1String("success")).toBool()) {
                 status = SocialNetworkInterface::Idle;
                 if (action == FacebookInterfacePrivate::LikeAction) {
                     liked = true;

--- a/src/facebook/facebookcommentinterface.cpp
+++ b/src/facebook/facebookcommentinterface.cpp
@@ -66,7 +66,7 @@ void FacebookCommentInterfacePrivate::finishedHandler()
 
     if (action == FacebookInterfacePrivate::LikeAction || action == FacebookInterfacePrivate::DeleteLikeAction) {
         // user initiated a "like" or "unlike" request.
-        if (replyData == QString(QLatin1String("true"))) {
+        if (responseData.value(QLatin1String("success")).toBool()) {
             status = SocialNetworkInterface::Idle;
             liked = (action == FacebookInterfacePrivate::LikeAction);
             emit q->statusChanged();

--- a/src/facebook/facebookphotointerface.cpp
+++ b/src/facebook/facebookphotointerface.cpp
@@ -72,7 +72,7 @@ void FacebookPhotoInterfacePrivate::finishedHandler()
         case FacebookInterfacePrivate::TagAction:        // flow
         case FacebookInterfacePrivate::DeleteTagAction:  // flow
         case FacebookInterfacePrivate::DeleteCommentAction: {
-            if (replyData == QString(QLatin1String("true"))) {
+            if (responseData.value(QLatin1String("success")).toBool()) {
                 status = SocialNetworkInterface::Idle;
                 if (action == FacebookInterfacePrivate::LikeAction) {
                     liked = true;

--- a/src/facebook/facebookpostinterface.cpp
+++ b/src/facebook/facebookpostinterface.cpp
@@ -69,7 +69,7 @@ void FacebookPostInterfacePrivate::finishedHandler()
         case FacebookInterfacePrivate::LikeAction:        // flow down.
         case FacebookInterfacePrivate::DeleteLikeAction:  // flow down.
         case FacebookInterfacePrivate::DeleteCommentAction: {
-            if (replyData == QString(QLatin1String("true"))) {
+            if (responseData.value(QLatin1String("success")).toBool()) {
                 status = SocialNetworkInterface::Idle;
                 if (action == FacebookInterfacePrivate::LikeAction) {
                     liked = true;

--- a/src/facebook/facebookuserinterface.cpp
+++ b/src/facebook/facebookuserinterface.cpp
@@ -85,7 +85,7 @@ void FacebookUserInterfacePrivate::finishedHandler()
     switch (action) {
         case FacebookInterfacePrivate::DeletePhotoAction: // flow down.
         case FacebookInterfacePrivate::DeleteAlbumAction: {
-            if (replyData == QString(QLatin1String("true"))) {
+            if (responseData.value(QLatin1String("success")).toBool()) {
                 status = SocialNetworkInterface::Idle;
                 emit q->statusChanged();
                 emit q->responseReceived(responseData);

--- a/src/identifiablecontentiteminterface.cpp
+++ b/src/identifiablecontentiteminterface.cpp
@@ -247,7 +247,7 @@ void IdentifiableContentItemInterfacePrivate::removeHandler()
         return;
     }
 
-    // Default just checks to see if the response is the text "true".
+    // Default just checks to see if the response's "success" field is true.
     // If it is, this handler deletes the reply(), sets the status to invalid.
     // If it isn't, this handler deletes the reply(), sets the status to error,
     // and emits responseReceived() with the given data.
@@ -257,7 +257,7 @@ void IdentifiableContentItemInterfacePrivate::removeHandler()
     QVariantMap responseData = ContentItemInterfacePrivate::parseReplyData(replyData, &ok);
     if (!ok)
         responseData.insert("response", replyData);
-    if (replyData == QString(QLatin1String("true"))) {
+    if (responseData.value(QLatin1String("success")).toBool()) {
         status = SocialNetworkInterface::Invalid; // We have been removed, so we are now invalid.
         emit q->statusChanged();
         emit q->responseReceived(responseData);


### PR DESCRIPTION
Earlier facebook replied to some requests with simple "true" or "false"
string. In v2.2 all the replies are wrapped into json-object. Modified
to handle reponse status correctly.